### PR TITLE
fix: out of bound write

### DIFF
--- a/lib/deepin_pw_check.c
+++ b/lib/deepin_pw_check.c
@@ -658,7 +658,8 @@ static char *get_pw_validate_policy_by_conf(int level, const char *conf_file) {
 
     const char *read_type = iniparser_getstring(dic, "Password:VALIDATE_POLICY", "");
 
-    strcpy(out_buff, read_type);
+    strncpy(out_buff, read_type, BUFF_SIZE - 1);
+    out_buff[BUFF_SIZE - 1]='\0';
     iniparser_freedict(dic);
     return out_buff;
 }


### PR DESCRIPTION
In the deepin-pw-check/lib/deepin_pw_check.c file, out-of-bounds writes exist in the get_pw_validate_policy_by_conf function. If the length of the value in the conf_file for Password:VALIDATE_POLICY is greater than the length of the global variable out_buff (=512), illegal writes may occur.
![image](https://user-images.githubusercontent.com/85945386/231474760-3fd80dac-4024-41f6-bd61-f567b3a1d236.png)
For example, construct the following dde.conf file：
![image](https://user-images.githubusercontent.com/85945386/231470478-a140ba42-84d0-4903-beed-db24f270d3f3.png)
Construct the following test program to trigger the vulnerability:
![image](https://user-images.githubusercontent.com/85945386/231470606-a2d13742-a439-4c04-bdfc-541a06af782f.png)
Use gdb-peda to debug test program, before strcpy execution: contents at out_buff+512 are null.
After strcpy execution, the contents of out_buff+512: have been maliciously written to the string we constructed
![image](https://user-images.githubusercontent.com/85945386/231622981-4d4c105d-fb6f-4b3b-a1a1-c70d2c7b5b14.png)
Therefore, for safety reasons, the strcpy function here is best replaced by the strncpy function.
This is the debugging result of replacing it with strncpy. In the same input case, the last character of out_buff is filled with \0 and no out-of-bounds writing occurs
![image](https://user-images.githubusercontent.com/85945386/231623032-5593cca0-26d9-400d-a9e8-1fd21d38293e.png)

