### PR TITLE
 fix: fix out-of-buffer vulnerability

### DIFF
--- a/lib/deepin_pw_check.c
+++ b/lib/deepin_pw_check.c
@@ -132,7 +132,8 @@ retry:
     options->palindrome_min_num = iniparser_getint(dic, "Password:PALINDROME_NUM", 0);
     options->check_word = iniparser_getint(dic, "Password:WORD_CHECK", 0);
     dict_buff = iniparser_getstring(dic, "Password:DICT_PATH", "");
-    strcpy(options->dict_path, dict_buff);
+    strncpy(options->dict_path, dict_buff, sizeof(options->dict_path));
+    options->dict_path[sizeof(options->dict_path) - 1] = '\0';
     options->monotone_character_num = iniparser_getint(dic, "Password:MONOTONE_CHARACTER_NUM", 0);
     options->consecutive_same_character_num =
             iniparser_getint(dic, "Password:CONSECUTIVE_SAME_CHARACTER_NUM", 0);
@@ -159,7 +160,8 @@ static struct Options *get_default_options(int level, const char *dict_path, con
         if (strcmp(options->dict_path, "") == 0) {
             options->dict_path[0] = '\0';
         } else {
-            strcpy(options->dict_path, dict_path);
+            strncpy(options->dict_path, dict_path, sizeof(options->dict_path));
+            options->dict_path[sizeof(options->dict_path) - 1] = '\0';
         }
     }
 


### PR DESCRIPTION
In the deepin-pw-check/lib/deepin_pw_check.c file, out-of-buffer writes exist in the load_pwd_conf and get_default_options function if the lengths of dict_buff or dict_path exceed.
In  _load_pwd_conf_  function:
![I_(Q)NOP4FNGL SHVUZO4D2](https://user-images.githubusercontent.com/51450364/233842041-55c0435f-9d35-45bb-a43b-5ed5f248a175.png)
In  _get_default_options_  function:
![G5T6J@NZC9K{%%B8M CQR Y](https://user-images.githubusercontent.com/51450364/233842103-be1658eb-10f8-4a5d-9a07-a8dfcea229bc.png)
The content size of the buffer ready to be copied from  should be checked before performing the **strcpy** invocation.