### PR TITLE
fix: fix out-of-buffer vulnerability

### DIFF
--- a/lib/deepin_pw_check.c
+++ b/lib/deepin_pw_check.c
@@ -132,7 +132,8 @@ retry:
     options->palindrome_min_num = iniparser_getint(dic, "Password:PALINDROME_NUM", 0);
     options->check_word = iniparser_getint(dic, "Password:WORD_CHECK", 0);
     dict_buff = iniparser_getstring(dic, "Password:DICT_PATH", "");
-    strcpy(options->dict_path, dict_buff);
+    strncpy(options->dict_path, dict_buff, sizeof(options->dict_path));
+    options->dict_path[sizeof(options->dict_path) - 1] = '\0';
     options->monotone_character_num = iniparser_getint(dic, "Password:MONOTONE_CHARACTER_NUM", 0);
     options->consecutive_same_character_num =
             iniparser_getint(dic, "Password:CONSECUTIVE_SAME_CHARACTER_NUM", 0);
@@ -159,7 +160,8 @@ static struct Options *get_default_options(int level, const char *dict_path, con
         if (strcmp(options->dict_path, "") == 0) {
             options->dict_path[0] = '\0';
         } else {
-            strcpy(options->dict_path, dict_path);
+            strncpy(options->dict_path, dict_path, sizeof(options->dict_path));
+            options->dict_path[sizeof(options->dict_path) - 1] = '\0';
         }
     }
 


### PR DESCRIPTION
In the deepin-pw-check/lib/deepin_pw_check.c file, out-of-buffer writes exist in the load_pwd_conf and get_default_options function if the lengths of dict_buff or dict_path exceed.
In _load_pwd_conf function_:
![image](https://user-images.githubusercontent.com/51450364/233908601-45a9688f-1302-4f8a-9cf8-ca74fa534e5d.png)
In _get_default_options_ function:
![image](https://user-images.githubusercontent.com/51450364/233908655-7422f8dc-5a44-40a9-bd14-6e3c3eec3742.png)
The content size of the buffer ready to be copied from should be checked before performing the **strcpy** invocation.