### PR TITLE
fix: deepin-pw-check 特权进程安全整改导致服务无法启动

### DIFF
--- a/debian/deepin-pw-check.install
+++ b/debian/deepin-pw-check.install
@@ -2,3 +2,4 @@ usr/lib/deepin-pw-check
 usr/share/dbus-1/system.d
 usr/share/dbus-1/system-services
 usr/share/polkit-1/actions/
+lib/systemd/system/*


### PR DESCRIPTION
  未正确安装service文件
Issue: https://pms.uniontech.com/bug-view-281621.html