### PR TITLE
refactor: improve build security flags handling

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ export PAM_MODULE_DIR = usr/lib/$(DEB_HOST_MULTIARCH)/security
 export PKG_FILE_DIR = usr/lib/pkgconfig
 export GO111MODULE = off
 export GOCACHE=/tmp/
+export CFLAGS = -fstack-protector-strong -z relro -z noexecstack -z now -pie -D_FORTIFY_SOURCE=2
 
 ifneq ($(DEB_BUILD_ARCH), mips64el)
 	export GOBUILD_OPTIONS=-ldflags '-linkmode=external -extldflags "-pie"'


### PR DESCRIPTION
1. Split security build options into separate CFLAGS variable for better maintainability
2. Move security flags to debian/rules to centralize build configurations
3. Keep -fPIC as a separate flag since it's required for position- independent code
4. Add FORTIFY_SOURCE protection for additional security hardening
5. Update all compilation commands to use CFLAGS consistently

The changes make the build system more modular and maintainable while maintaining all security hardening features. The security flags are now defined in one place (debian/rules) and applied consistently across all compilation commands.

refactor: 改进构建安全标志处理

1. 将安全构建选项拆分为单独的 CFLAGS 变量以提高可维护性
2. 将安全标志移至 debian/rules 以集中构建配置
3. 保持 -fPIC 作为单独标志，因为它是位置无关代码所必需的
4. 添加 FORTIFY_SOURCE 保护以增强安全性
5. 更新所有编译命令以一致地使用 CFLAGS

这些更改使构建系统更加模块化和可维护，同时保留所有安全加固功能。安全标志
现在集中定义在一个地方(debian/rules)并一致地应用于所有编译命令。