### PR TITLE
fix: install path for systemd-services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,8 +79,8 @@ install: translate
 	cp out/bin/deepin-pw-check ${DESTDIR}${PREFIX}/lib/deepin-pw-check/
 	mkdir -p ${DESTDIR}${PREFIX}/share/polkit-1/actions
 	cp -r misc/polkit-action/*.policy ${DESTDIR}${PREFIX}/share/polkit-1/actions
-	mkdir -p ${DESTDIR}/lib/systemd/system
-	cp  misc/systemd-service/deepin-passwd-conf.service ${DESTDIR}/lib/systemd/system/
+	mkdir -p ${DESTDIR}${PREFIX}/lib/systemd/system
+	cp misc/systemd-service/deepin-passwd-conf.service ${DESTDIR}${PREFIX}/lib/systemd/system/
 
 test: $(addprefix unit_test/, $(SRCS_C)) clean_test
 

--- a/debian/deepin-pw-check.install
+++ b/debian/deepin-pw-check.install
@@ -2,4 +2,4 @@ usr/lib/deepin-pw-check
 usr/share/dbus-1/system.d
 usr/share/dbus-1/system-services
 usr/share/polkit-1/actions/
-lib/systemd/system/*
+usr/lib/systemd/system/*


### PR DESCRIPTION
e.g. should be in `usr/lib` rather that `lib`