### PR TITLE
chore: update changelog to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-pw-check (6.0.8) unstable; urgency=medium
+
+  * fix: remove systemd-tmpfiles configuration for dde.conf (#54)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 05 Feb 2026 19:52:00 +0800
+
 deepin-pw-check (6.0.7) unstable; urgency=medium
 
   * fix: update Go build linker flags for security hardening


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.8

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.8
- 目标分支: master
