### PR TITLE
fix(pw-check): use absolute path for pwd-conf-update

### DIFF
--- a/lib/deepin_pw_check.c
+++ b/lib/deepin_pw_check.c
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -107,7 +107,7 @@ retry:
         DEBUG("ERROR: open file %s failed!", conf_file);
         if (retry_cnt < 1) {
             DEBUG("exec pwd-conf-update to create <%s>", conf_file);
-            system("pwd-conf-update");
+            system("/usr/bin/pwd-conf-update");
             retry_cnt++;
             goto retry;
         }


### PR DESCRIPTION
1. Use absolute path /usr/bin/pwd-conf-update instead of bare command name to prevent PATH hijacking vulnerability
2. Security scan flagged system() call as CWE-78 risk; hardcoded absolute path eliminates PATH search vector

Log: Use absolute path in system() call to prevent PATH hijacking

fix(pw-check): 使用绝对路径调用 pwd-conf-update

1. 将 system("pwd-conf-update") 改为 system("/usr/bin/pwd-conf-update")， 防止 PATH 劫持攻击
2. 安全扫描将 system() 调用标记为 CWE-78 风险， 硬编码绝对路径消除了 PATH 搜索攻击面

Log: 在 system() 调用中使用绝对路径防止 PATH 劫持